### PR TITLE
Allow Output first parameters to be Stringable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+-   Stringable interface.
+-   MessageStringable class.
+
 ### Changed
+
+-   Allow Output methods' first parameter to be Stringable.
 
 ### Deprecated
 

--- a/src/Output/ConsoleOutput.ts
+++ b/src/Output/ConsoleOutput.ts
@@ -1,4 +1,5 @@
 import { Output } from './Output.ts'
+import { Stringable } from '../Stringable/Stringable.ts'
 import { Console } from 'node:console'
 import { stderr, stdout } from 'node:process'
 
@@ -27,60 +28,65 @@ export class ConsoleOutput implements Output {
 	 * Prints an error to stderr stream.
 	 *
 	 * @since 0.1.0
+	 * @since unreleased - Allow first param to be Stringable.
 	 *
-	 * @param {string} message           Message to output.
-	 * @param {any[]}  ...optionalParams Optional parameters.
+	 * @param {string | Stringable} message           Message to output.
+	 * @param {any[]}               ...optionalParams Optional parameters.
 	 */
-	public error(message: string, ...optionalParams: any[]): void {
-		this.console.error(message, ...optionalParams)
+	public error(message: string | Stringable, ...optionalParams: any[]): void {
+		this.console.error(message.toString(), ...optionalParams)
 	}
 
 	/**
 	 * Prints a warning to stderr stream.
 	 *
 	 * @since 0.1.0
+	 * @since unreleased - Allow first param to be Stringable.
 	 *
-	 * @param {string} message           Message to output.
-	 * @param {any[]}  ...optionalParams Optional parameters.
+	 * @param {string | Stringable} message           Message to output.
+	 * @param {any[]}               ...optionalParams Optional parameters.
 	 */
-	public warn(message: string, ...optionalParams: any[]): void {
-		this.console.warn(message, ...optionalParams)
+	public warn(message: string | Stringable, ...optionalParams: any[]): void {
+		this.console.warn(message.toString(), ...optionalParams)
 	}
 
 	/**
 	 * Prints a log message to stdout stream.
 	 *
 	 * @since 0.1.0
+	 * @since unreleased - Allow first param to be Stringable.
 	 *
-	 * @param {string} message           Message to output.
-	 * @param {any[]}  ...optionalParams Optional parameters.
+	 * @param {string | Stringable} message           Message to output.
+	 * @param {any[]}               ...optionalParams Optional parameters.
 	 */
-	public log(message: string, ...optionalParams: any[]): void {
-		this.console.log(message, ...optionalParams)
+	public log(message: string | Stringable, ...optionalParams: any[]): void {
+		this.console.log(message.toString(), ...optionalParams)
 	}
 
 	/**
 	 * Prints an info message to stdout stream.
 	 *
 	 * @since 0.1.0
+	 * @since unreleased - Allow first param to be Stringable.
 	 *
-	 * @param {string} message           Message to output.
-	 * @param {any[]}  ...optionalParams Optional parameters.
+	 * @param {string | Stringable} message           Message to output.
+	 * @param {any[]}               ...optionalParams Optional parameters.
 	 */
-	public info(message: string, ...optionalParams: any[]): void {
-		this.console.info(message, ...optionalParams)
+	public info(message: string | Stringable, ...optionalParams: any[]): void {
+		this.console.info(message.toString(), ...optionalParams)
 	}
 
 	/**
 	 * Print a debug message to stdout stream.
 	 *
 	 * @since 0.1.0
+	 * @since unreleased - Allow first param to be Stringable.
 	 *
-	 * @param {string} message           Message to output.
-	 * @param {any[]}  ...optionalParams Optional parameters.
+	 * @param {string | Stringable} message           Message to output.
+	 * @param {any[]}               ...optionalParams Optional parameters.
 	 */
-	public debug(message: string, ...optionalParams: any[]): void {
-		this.console.debug(message, ...optionalParams)
+	public debug(message: string | Stringable, ...optionalParams: any[]): void {
+		this.console.debug(message.toString(), ...optionalParams)
 	}
 
 	/**

--- a/src/Output/Output.ts
+++ b/src/Output/Output.ts
@@ -1,3 +1,5 @@
+import { Stringable } from '../Stringable/Stringable.ts'
+
 /* eslint @typescript-eslint/no-explicit-any: 0 -- Params can be anything. */
 
 /**
@@ -11,48 +13,48 @@ export interface Output {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param {string} message           Message to output.
-	 * @param {any[]}  ...optionalParams Optional parameters.
+	 * @param {string | Stringable} message           Message to output.
+	 * @param {any[]}               ...optionalParams Optional parameters.
 	 */
-	error(message: string, ...optionalParams: any[]): void
+	error(message: string | Stringable, ...optionalParams: any[]): void
 
 	/**
 	 * Prints a warning to an error stream.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param {string} message           Message to output.
-	 * @param {any[]}  ...optionalParams Optional parameters.
+	 * @param {string | Stringable} message           Message to output.
+	 * @param {any[]}               ...optionalParams Optional parameters.
 	 */
-	warn(message: string, ...optionalParams: any[]): void
+	warn(message: string | Stringable, ...optionalParams: any[]): void
 
 	/**
 	 * Prints a log message to an output stream.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param {string} message           Message to output.
-	 * @param {any[]}  ...optionalParams Optional parameters.
+	 * @param {string | Stringable} message           Message to output.
+	 * @param {any[]}               ...optionalParams Optional parameters.
 	 */
-	log(message: string, ...optionalParams: any[]): void
+	log(message: string | Stringable, ...optionalParams: any[]): void
 
 	/**
 	 * Prints an info message to an output stream.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param {string} message           Message to output.
-	 * @param {any[]}  ...optionalParams Optional parameters.
+	 * @param {string | Stringable} message           Message to output.
+	 * @param {any[]}               ...optionalParams Optional parameters.
 	 */
-	info(message: string, ...optionalParams: any[]): void
+	info(message: string | Stringable, ...optionalParams: any[]): void
 
 	/**
 	 * Print a debug message to an output stream.
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param {string} message           Message to output.
-	 * @param {any[]}  ...optionalParams Optional parameters.
+	 * @param {string | Stringable} message           Message to output.
+	 * @param {any[]}               ...optionalParams Optional parameters.
 	 */
-	debug(message: string, ...optionalParams: any[]): void
+	debug(message: string | Stringable, ...optionalParams: any[]): void
 }

--- a/src/Stringable/MessageStringable.ts
+++ b/src/Stringable/MessageStringable.ts
@@ -1,0 +1,22 @@
+import { Stringable } from './Stringable.ts'
+
+/**
+ * Object whose constructor takes a message and returns it from toString
+ * method.
+ *
+ * @since unreleased
+ */
+export class MessageStringable implements Stringable {
+	constructor(private message: string) {}
+
+	/**
+	 * Converts object to a string.
+	 *
+	 * @since  unreleased
+	 *
+	 * @return {string}
+	 */
+	toString(): string {
+		return this.message
+	}
+}

--- a/src/Stringable/Stringable.ts
+++ b/src/Stringable/Stringable.ts
@@ -1,0 +1,15 @@
+/**
+ * Object which implements toString method.
+ *
+ * @since unreleased
+ */
+export interface Stringable {
+	/**
+	 * Converts object to a string.
+	 *
+	 * @since  unreleased
+	 *
+	 * @return {string}
+	 */
+	toString(): string
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,7 @@
-export { ConsoleOutput } from './Output/ConsoleOutput.ts'
+// Output.
 export { type Output } from './Output/Output.ts'
+export { ConsoleOutput } from './Output/ConsoleOutput.ts'
+
+// Stringable.
+export { type Stringable } from './Stringable/Stringable.ts'
+export { MessageStringable } from './Stringable/MessageStringable.ts'

--- a/tests/Output/ConsoleOutput.test.ts
+++ b/tests/Output/ConsoleOutput.test.ts
@@ -1,5 +1,7 @@
 import { ConsoleOutput } from '../../src/Output/ConsoleOutput.ts'
-import { describe, expect, it, jest } from '@jest/globals'
+import { MessageStringable } from '../../src/Stringable/MessageStringable.ts'
+import { Stringable } from '../../src/Stringable/Stringable.ts'
+import { describe, expect, it, jest, test } from '@jest/globals'
 import { Console } from 'node:console'
 import { Writable } from 'node:stream'
 
@@ -17,58 +19,93 @@ class MockConsole extends Console {
 
 describe('ConsoleOutput', () => {
 	describe('error', () => {
-		it('should print an error to stderr stream', () => {
-			const mockConsole = new MockConsole()
-			const output = new ConsoleOutput(mockConsole)
+		const errorMessage = 'An error occurred.'
 
-			output.error('An error occurred.')
+		describe.each([errorMessage, new MessageStringable(errorMessage)])(
+			'should print an error to stderr stream',
+			(message: string | Stringable) => {
+				test(message.constructor.name, () => {
+					const mockConsole = new MockConsole()
+					const output = new ConsoleOutput(mockConsole)
 
-			expect(mockConsole.error).toHaveBeenCalled()
-		})
+					output.error(message)
+
+					expect(mockConsole.error).toHaveBeenCalledWith(errorMessage)
+				})
+			},
+		)
 	})
 
 	describe('warn', () => {
-		it('should print a warning to stderr stream', () => {
-			const mockConsole = new MockConsole()
-			const output = new ConsoleOutput(mockConsole)
+		const warningMessage = 'An warning message.'
 
-			output.warn('A warning message.')
+		describe.each([warningMessage, new MessageStringable(warningMessage)])(
+			'should print a warning to stderr stream',
+			(message: string | Stringable) => {
+				test(message.constructor.name, () => {
+					const mockConsole = new MockConsole()
+					const output = new ConsoleOutput(mockConsole)
 
-			expect(mockConsole.warn).toHaveBeenCalled()
-		})
+					output.warn(message)
+
+					expect(mockConsole.warn).toHaveBeenCalledWith(warningMessage)
+				})
+			},
+		)
 	})
 
 	describe('log', () => {
-		it('should print a log message to stdout stream', () => {
-			const mockConsole = new MockConsole()
-			const output = new ConsoleOutput(mockConsole)
+		const logMessage = 'A log message.'
 
-			output.log('A log message.')
+		describe.each([logMessage, new MessageStringable(logMessage)])(
+			'should print a log message to stdout stream',
+			(message: string | Stringable) => {
+				test(message.constructor.name, () => {
+					const mockConsole = new MockConsole()
+					const output = new ConsoleOutput(mockConsole)
 
-			expect(mockConsole.log).toHaveBeenCalled()
-		})
+					output.log(message)
+
+					expect(mockConsole.log).toHaveBeenCalledWith(logMessage)
+				})
+			},
+		)
 	})
 
 	describe('info', () => {
-		it('should print an info message to stdout stream', () => {
-			const mockConsole = new MockConsole()
-			const output = new ConsoleOutput(mockConsole)
+		const infoMessage = 'An info message.'
 
-			output.info('A info message.')
+		describe.each([infoMessage, new MessageStringable(infoMessage)])(
+			'should print an info message to stdout stream',
+			(message: string | Stringable) => {
+				test(message.constructor.name, () => {
+					const mockConsole = new MockConsole()
+					const output = new ConsoleOutput(mockConsole)
 
-			expect(mockConsole.info).toHaveBeenCalled()
-		})
+					output.info(message)
+
+					expect(mockConsole.info).toHaveBeenCalledWith(infoMessage)
+				})
+			},
+		)
 	})
 
 	describe('debug', () => {
-		it('should print a debug message to stdout stream', () => {
-			const mockConsole = new MockConsole()
-			const output = new ConsoleOutput(mockConsole)
+		const debugMessage = 'A debug message.'
 
-			output.debug('A debug message.')
+		describe.each([debugMessage, new MessageStringable(debugMessage)])(
+			'should print a debug message to stdout stream',
+			(message: string | Stringable) => {
+				test(message.constructor.name, () => {
+					const mockConsole = new MockConsole()
+					const output = new ConsoleOutput(mockConsole)
 
-			expect(mockConsole.debug).toHaveBeenCalled()
-		})
+					output.debug(message)
+
+					expect(mockConsole.debug).toHaveBeenCalledWith(debugMessage)
+				})
+			},
+		)
 	})
 
 	describe('getConsole', () => {

--- a/tests/Stringable/MessageStringable.test.ts
+++ b/tests/Stringable/MessageStringable.test.ts
@@ -1,0 +1,10 @@
+import { MessageStringable } from '../../src/Stringable/MessageStringable.ts'
+import { describe, expect, it } from '@jest/globals'
+
+describe('MessageStringable', () => {
+	it('should take a message and return it from toString method', () => {
+		const message = 'a message'
+
+		expect(new MessageStringable(message).toString()).toBe(message)
+	})
+})


### PR DESCRIPTION
## Summary

Allows `Output`'s `error`, `warn`, `log`, `info`, and `debug` methods to receive first parameter as `string` or `Stringable` (any object with `toString` method).

## Testing

`npm test -- Stringable`

```
 PASS  tests/Stringable/MessageStringable.test.ts
  MessageStringable
    ✓ should take a message and return it from toString method (2 ms)
```

`npm test -- Output`

```
 PASS  tests/Output/ConsoleOutput.test.ts
  ConsoleOutput
    error
      should print an error to stderr stream
        ✓ String (4 ms)
        ✓ MessageStringable (1 ms)
    warn
      should print a warning to stderr stream
        ✓ String (1 ms)
        ✓ MessageStringable
    log
      should print a log message to stdout stream
        ✓ String
        ✓ MessageStringable
    info
      should print an info message to stdout stream
        ✓ String (1 ms)
        ✓ MessageStringable (1 ms)
    debug
      should print a debug message to stdout stream
        ✓ String (1 ms)
        ✓ MessageStringable
```